### PR TITLE
fix auto-scroll to bottom of terminal when command wraps for chrome

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -5031,9 +5031,7 @@
         if (settings.height) {
             self.height(settings.height);
         }
-        var agent = navigator.userAgent.toLowerCase();
-        if (!agent.match(/(webkit)[ \/]([\w.]+)/) &&
-            self[0].tagName.toLowerCase() == 'body') {
+        if (self[0].tagName.toLowerCase() == 'body') {
             scroll_object = $('html');
         } else {
             scroll_object = self;


### PR DESCRIPTION
fixes #33 
This fix for chromium seems to be the cause.
https://bugs.chromium.org/p/chromium/issues/detail?id=157855
Since Chrome now operates the same as other browsers regarding treatment of scrolling I removed the Webkit detection line when setting the scroll_object and tested in the latest Chrome/Firefox/IE/Edge